### PR TITLE
Adding m4 to a list of available image types

### DIFF
--- a/lib/coreos.py
+++ b/lib/coreos.py
@@ -12,7 +12,8 @@ version_file_name = "version.txt"
 image_types = {
     't2': 'hvm',
     'm1': 'pv',
-    'c4': 'hvm'
+    'c4': 'hvm',
+    'm4': 'hvm'
 }
 
 def release_metadata_url(channel, version, file_name):


### PR DESCRIPTION
Discovered that `m4` instance types are more suitable for the kind of business we are doing...
